### PR TITLE
docs: python.pythonPath vsc setting superseded by python.defaultInterpreterPath

### DIFF
--- a/docs/learning/vscode/index.en.md
+++ b/docs/learning/vscode/index.en.md
@@ -107,7 +107,7 @@ Inside the project, you can also create a file: settings.json inside the .vscode
 
 ```
 {
-  "python.pythonPath": "/Users/jeydi/Progetti/mioprogetto/.venv/bin/python"
+  "python.defaultInterpreterPath": "/Users/jeydi/Progetti/mioprogetto/.venv/bin/python"
 }
 ```
 

--- a/docs/learning/vscode/index.md
+++ b/docs/learning/vscode/index.md
@@ -106,7 +106,7 @@ All’interno del progetto potete anche creare un file: settings.json all’inte
 
 ```
 {
-  "python.pythonPath": "/Users/jeydi/Progetti/mioprogetto/.venv/bin/python"
+  "python.defaultInterpreterPath": "/Users/jeydi/Progetti/mioprogetto/.venv/bin/python"
 }
 ```
 


### PR DESCRIPTION
Seems that `python.pythonPath` vsc setting has been superseded by `python.defaultInterpreterPath`.

PS: thank you for your amazing work, I'm learning a ton by following you!