### PR TITLE
chore: update `Ruff` configs

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -6,7 +6,36 @@ target-version = "py39"
 # A list of file patterns to include when linting.
 include = ["**/pyproject.toml", "*.ipynb", "*.py", "*.pyi"]
 
-# Rules: https://beta.ruff.rs/docs/rules/
+# Always autofix, but never try to fix `F401` (unused imports).
+fix = true
+unfixable = ["F401"]
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = ">=(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+# Exclude a variety of commonly ignored directories (you can have some problems)
+exclude = [
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    ".venv"
+]
+
+[lint]
+# Rules: https://docs.astral.sh/ruff/rules/
 # Enable Pyflakes `E` and `F` codes by default.
 select = [
     #default
@@ -42,47 +71,19 @@ ignore = [
     "D100",
 ]
 
-# Always autofix, but never try to fix `F401` (unused imports).
-fix = true
-unfixable = ["F401"]
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = ">=(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-# Exclude a variety of commonly ignored directories (you can have some problems)
-exclude = [
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
-    ".venv"
-]
-
-[mccabe]
+[lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
-[flake8-quotes]
+[lint.flake8-quotes]
 docstring-quotes = "double"
 
-[pydocstyle]
+[lint.pydocstyle]
 convention = "google"
 
-[isort]
+[lint.isort]
 known-third-party = ["fastapi", "pydantic", "starlette"]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "__init__.py" = ["D104", "F401", "I002"]
 "test*.py"    = ["S101", "T201"]


### PR DESCRIPTION
Update `Ruff` configs according to docs (eg nest _linter-specific_ configs under `[lint]`). 